### PR TITLE
Added prerequisites for Install-ADDSForest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Create a vulnerable active directory that's allowing you to test most of active 
 ### Example
 ```powershell
 # if you didn't install Active Directory yet , you can try 
+Install-windowsfeature AD-domain-services
+Import-Module ADDSDeployment
 Install-ADDSForest -CreateDnsDelegation:$false -DatabasePath "C:\\Windows\\NTDS" -DomainMode "7" -DomainName "cs.org" -DomainNetbiosName "cs" -ForestMode "7" -InstallDns:$true -LogPath "C:\\Windows\\NTDS" -NoRebootOnCompletion:$false -SysvolPath "C:\\Windows\\SYSVOL" -Force:$true
 # if you already installed Active Directory, just run the script !
 IEX((new-object net.webclient).downloadstring("https://raw.githubusercontent.com/wazehell/vulnerable-AD/master/vulnad.ps1"));


### PR DESCRIPTION
If you don't enable the AD-domain-services windows feature on a fresh server Install-ADDSForest will not work